### PR TITLE
feature: conditional per request timeout setting

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -58,6 +58,20 @@ require "rack-timeout"
 use Rack::Timeout, service_timeout: 5
 ```
 
+### Conditional timeout
+
+You can set a conditional timeout per request.
+Although make sure to always meet your requirements (e.g. Heroku 30s timeout) in all cases.
+If the block returns `nil` or `false`, timeout will be disabled for this request.
+
+```ruby
+# set conditional_timeout to a callable block
+# config/initializers/rack_timeout.rb
+Rack::Timeout.conditional_timeout = proc { |env| env["PATH_INFO"] =~ /^\/admin/ ? 20 : 5 }
+
+# equivalent for Sinatra/Rack apps
+use Rack::Timeout, conditional_timeout: ->(env) { env["PATH_INFO"] =~ /^\/admin/ ? 20 : 5 }
+```
 
 The Rabbit Hole
 ---------------

--- a/lib/rack/timeout/legacy.rb
+++ b/lib/rack/timeout/legacy.rb
@@ -8,7 +8,7 @@ require_relative "support/namespace"
 module Rack::Timeout::ClassLevelProperties
 
   module ClassMethods
-    attr_accessor :service_timeout, :wait_timeout, :wait_overtime, :service_past_wait
+    attr_accessor :service_timeout, :wait_timeout, :wait_overtime, :service_past_wait, :conditional_timeout
     alias_method :timeout=, :service_timeout=
 
     [ :service_timeout=,
@@ -16,6 +16,7 @@ module Rack::Timeout::ClassLevelProperties
       :wait_timeout=,
       :wait_overtime=,
       :service_past_wait=,
+      :conditional_timeout=
     ].each do |isetter|
       setter = instance_method(isetter)
       define_method(isetter) do |x|
@@ -29,6 +30,10 @@ module Rack::Timeout::ClassLevelProperties
 
     [:service_timeout, :wait_timeout, :wait_overtime].each do |m|
       define_method(m) { read_timeout_property self.class.send(m), super() }
+    end
+
+    def conditional_timeout
+      self.class.conditional_timeout || super
     end
 
     def service_past_wait


### PR DESCRIPTION
### Conditional timeout

You can set a conditional timeout per request.
Although make sure to always meet your requirements (e.g. Heroku 30s timeout) in all cases.
If the block returns `nil` or `false`, timeout will be disabled for this request.

``` ruby
# set conditional_timeout to a callable block
# config/initializers/rack_timeout.rb
Rack::Timeout.conditional_timeout = proc { |env| env["PATH_INFO"] =~ /^\/admin/ ? 20 : 5 }

# equivalent for Sinatra/Rack apps
use Rack::Timeout, conditional_timeout: ->(env) { env["PATH_INFO"] =~ /^\/admin/ ? 20 : 5 }
```
