### PR TITLE
Update the gemspec's homepage to the current repo URL

### DIFF
--- a/rack-timeout.gemspec
+++ b/rack-timeout.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |spec|
   spec.summary     = "Abort requests that are taking too long"
   spec.description = "Rack middleware which aborts requests that have been running for longer than a specified timeout."
   spec.version     = "0.5.1"
-  spec.homepage    = "http://github.com/heroku/rack-timeout"
+  spec.homepage    = "https://github.com/sharpstone/rack-timeout"
   spec.author      = "Caio Chassot"
   spec.email       = "caio@heroku.com"
   spec.files       = Dir[*%w( MIT-LICENSE CHANGELOG README.markdown lib/**/* doc/**/* )]


### PR DESCRIPTION
This reduces unnecessary redirection for users who visit here from https://rubygems.org/gems/rack-timeout.