### PR TITLE
add report_only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ service_timeout:   15     # RACK_TIMEOUT_SERVICE_TIMEOUT
 wait_timeout:      30     # RACK_TIMEOUT_WAIT_TIMEOUT
 wait_overtime:     60     # RACK_TIMEOUT_WAIT_OVERTIME
 service_past_wait: false  # RACK_TIMEOUT_SERVICE_PAST_WAIT
+report_only:       false  # RACK_TIMEOUT_REPORT_ONLY
 ```
 
 These settings can be overriden during middleware initialization or

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -1,6 +1,6 @@
 # Settings
 
-Rack::Timeout has 4 settings, each of which impacts when Rack::Timeout
+Rack::Timeout has 5 settings, each of which impacts when Rack::Timeout
 will raise an exception, and which type of exception will be raised.
 
 ### Service Timeout
@@ -47,3 +47,7 @@ This extra time is called *wait overtime* and can be set via `wait_overtime`. It
 Keep in mind that Heroku [recommends][uploads] uploading large files directly to S3, so as to prevent the dyno from being blocked for too long and hence unable to handle further incoming requests.
 
 [uploads]: https://devcenter.heroku.com/articles/s3#file-uploads
+
+### Report Only
+
+When `report_only` is set to `true` no exceptions will be raised and the request will continue to run (state changes will still be logged and obervers will still be called).

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -20,4 +20,10 @@ class BasicTest < RackTimeoutTest
       get "/", "", 'HTTP_X_REQUEST_START' => time_in_msec(Time.now - 100)
     end
   end
+
+  def test_report_only
+    self.settings = { wait_timeout: 15, report_only: true }
+    get "/", "", 'HTTP_X_REQUEST_START' => time_in_msec(Time.now - 100)
+    assert last_response.ok?
+  end
 end

--- a/test/env_settings_test.rb
+++ b/test/env_settings_test.rb
@@ -17,4 +17,11 @@ class EnvSettingsTest < RackTimeoutTest
     end
   end
 
+  def test_report_only
+    with_env(RACK_TIMEOUT_WAIT_TIMEOUT: 15, RACK_TIMEOUT_REPORT_ONLY: 'true') do
+      get "/", "", 'HTTP_X_REQUEST_START' => time_in_msec(Time.now - 100)
+      assert last_response.ok?
+    end
+  end
+
 end


### PR DESCRIPTION
this allows us to log/send error notifications via observers when we experience a timeout without the risk of corrupting some existing io process that raising an error brings. 