### PR TITLE
Load middleware in Rails 6

### DIFF
--- a/lib/rack/timeout/rails.rb
+++ b/lib/rack/timeout/rails.rb
@@ -4,10 +4,12 @@ class Rack::Timeout::Railtie < Rails::Railtie
   initializer("rack-timeout.prepend") do |app|
     next if Rails.env.test?
 
+    middleware = Rails::VERSION::MAJOR >= 6 ? app.middleware : app.config.middleware
+
     if defined?(ActionDispatch::RequestId)
-      app.config.middleware.insert_after(ActionDispatch::RequestId, Rack::Timeout)
+      middleware.insert_after(ActionDispatch::RequestId, Rack::Timeout)
     else
-      app.config.middleware.insert_before(Rack::Runtime, Rack::Timeout)
+      middleware.insert_before(Rack::Runtime, Rack::Timeout)
     end
   end
 end


### PR DESCRIPTION
This PR fixes https://github.com/sharpstone/rack-timeout/issues/153