### PR TITLE
README: Format code example, whitespace [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ stack `Rack::Timeout` gets inserted.
 
 ```ruby
 # Gemfile
-gem "rack-timeout", require:"rack/timeout/base"
+gem "rack-timeout", require: "rack/timeout/base"
 ```
 
 ```ruby


### PR DESCRIPTION
This PR is a tiny whiny change to the README code example: add a space between hash keys.