### PR TITLE
[WIP] Allow sending SIGTERM to workers on timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ service_timeout:   15     # RACK_TIMEOUT_SERVICE_TIMEOUT
 wait_timeout:      30     # RACK_TIMEOUT_WAIT_TIMEOUT
 wait_overtime:     60     # RACK_TIMEOUT_WAIT_OVERTIME
 service_past_wait: false  # RACK_TIMEOUT_SERVICE_PAST_WAIT
+term_on_timeout:   false  # RACK_TIMEOUT_TERM_ON_TIMEOUT
 ```
 
 These settings can be overriden during middleware initialization or

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -90,7 +90,8 @@ module Rack
         seconds_waited          = 0 if seconds_waited < 0                  # make up for potential time drift between the routing server and the application server
         final_wait_timeout      = wait_timeout + effective_overtime        # how long the request will be allowed to have waited
         seconds_service_left    = final_wait_timeout - seconds_waited      # first calculation of service timeout (relevant if request doesn't get expired, may be overriden later)
-        info.wait, info.timeout = seconds_waited, final_wait_timeout       # updating the info properties; info.timeout will be the wait timeout at this point
+        info.wait               = seconds_waited                           # updating the info properties; info.timeout will be the wait timeout at this point
+        info.timeout            = final_wait_timeout
         if seconds_service_left <= 0 # expire requests that have waited for too long in the queue (as they are assumed to have been dropped by the web server / routing layer at this point)
           RT._set_state! env, :expired
           raise RequestExpiryError.new(env), "Request older than #{info.ms(:timeout)}."

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -191,6 +191,5 @@ module Rack
     def self.notify_state_change_observers(env)
       @state_change_observers.values.each { |observer| observer.call(env) }
     end
-
   end
 end

--- a/lib/rack/timeout/logger.rb
+++ b/lib/rack/timeout/logger.rb
@@ -35,5 +35,4 @@ module Rack::Timeout::Logger
     @level      = new_level  || ::Logger::INFO
     self.logger = ::Rack::Timeout::StateChangeLoggingObserver.mk_logger(device, level)
   end
-
 end

--- a/lib/rack/timeout/logging-observer.rb
+++ b/lib/rack/timeout/logging-observer.rb
@@ -52,5 +52,4 @@ class Rack::Timeout::StateChangeLoggingObserver
       s
     end
   end
-
 end

--- a/lib/rack/timeout/logging-observer.rb
+++ b/lib/rack/timeout/logging-observer.rb
@@ -48,6 +48,7 @@ class Rack::Timeout::StateChangeLoggingObserver
       s << " wait="    << info.ms(:wait)    if info.wait
       s << " timeout=" << info.ms(:timeout) if info.timeout
       s << " service=" << info.ms(:service) if info.service
+      s << " term_on_timeout=" << info.term.to_s if info.term
       s << " state="   << info.state.to_s   if info.state
       s
     end

--- a/lib/rack/timeout/support/monotonic_time.rb
+++ b/lib/rack/timeout/support/monotonic_time.rb
@@ -25,5 +25,4 @@ module Rack::Timeout::MonotonicTime
   when RUBY_PLATFORM == "java"           ; alias fsecs fsecs_java
   else                                   ; alias fsecs fsecs_ruby
   end
-
 end

--- a/lib/rack/timeout/support/scheduler.rb
+++ b/lib/rack/timeout/support/scheduler.rb
@@ -151,5 +151,4 @@ class Rack::Timeout::Scheduler
   instance_methods(false).each do |m|
     define_singleton_method(m) { |*a, &b| singleton.send(m, *a, &b) }
   end
-
 end

--- a/lib/rack/timeout/support/timeout.rb
+++ b/lib/rack/timeout/support/timeout.rb
@@ -25,5 +25,4 @@ class Rack::Timeout::Scheduler::Timeout
   def self.timeout(secs, &block)
     (@singleton ||= new).timeout(secs, &block)
   end
-
 end

--- a/test/env_settings_test.rb
+++ b/test/env_settings_test.rb
@@ -16,5 +16,4 @@ class EnvSettingsTest < RackTimeoutTest
       assert last_response.ok?
     end
   end
-
 end

--- a/test/env_settings_test.rb
+++ b/test/env_settings_test.rb
@@ -16,4 +16,12 @@ class EnvSettingsTest < RackTimeoutTest
       assert last_response.ok?
     end
   end
+
+  def test_term
+    with_env(RACK_TIMEOUT_TERM_ON_TIMEOUT: 1) do
+      assert_raises(SignalException) do
+        get "/sleep"
+      end
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,5 +42,4 @@ class RackTimeoutTest < Test::Unit::TestCase
   def time_in_msec(t = Time.now)
     "#{t.tv_sec}#{t.tv_usec/1000}"
   end
-
 end


### PR DESCRIPTION
When rack-timeout fires then it can put an application in a "bad" state. This is due to https://www.schneems.com/2017/02/21/the-oldest-bug-in-ruby-why-racktimeout-might-hose-your-server/.

We can give applications the option of restarting the entire process when a timeout is hit by sending it a SIGTERM. Why would we want that?

While the `Thread.raise` api is unsafe, restarting a process is safe. If the application is running a multiple-worker webserver such as unicorn or puma, when the worker process gets a SIGTERM then it will be shut down and restarted by the "master" process.

In puma when `SIGTERM` is sent to a worker, that worker will stop accepting new requests, but continue to process all existing requests currently running in threads. This means that sending a SIGTERM to the current process will not affect requests that are currently running (this is a good thing).

What is the downside of sending a TERM to the current worker when there is a timeout? When you TERM a worker, you will lose some capacity to process requests until puma brings up another process. Puma may take a second or two to boot a new process. If all processes on a dyno are TERM'd then your app would stop serving requests until puma boots new processes which, again, would take time. If the application is hitting timeouts because it is under-provisioned then sending TERM to the process, reduces processing power and adds a delay in processing new requests. In the worst case, this could mean that the application is stuck in a process restart loop. 

Anecdotally I've seen that usually, applications can tolerate a number of timeout events. I say, usually, fewer than a dozen a day tend to not experience problems. I don't have an empirical number, but if I had to guess, I would say that it would make sense if it was related to MAX_THREADS. Why?

Imagine that every rack-timeout request that fails corrupts something. It's likely to be a connection of some kind, and if you've got MAX_THREADS=5 then you've got 5 database connections.

Since this is a theory I'm making the setting configurable so we can experiment with it in the wild.

cc/ @ericc572