### PR TITLE
Default of RACK_TIMEOUT_TERM_ON_TIMEOUT to zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1
+
+- RACK_TIMEOUT_TERM_ON_TIMEOUT can be set to zero to disable (https://github.com/sharpstone/rack-timeout/pull/161)
+
 ## 0.6.0
 
 - Allow sending SIGTERM to workers on timeout (https://github.com/sharpstone/rack-timeout/pull/157)

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -59,7 +59,7 @@ If your application timeouts fire frequently then [they can cause your applicati
 
 After the worker process exists will Puma's parent process know to boot a replacement worker. While one process is restarting, another can still serve requests (if you have more than 1 worker process per server/dyno). Between when a process exits and when a new process boots, there will be a reduction in throughput. If all processes are restarting, then incoming requests will be blocked while new processes boot.
 
-**How to enable** To enable this behavior you can set `term_on_timeout: 1` to an integer value. If you set it to zero or one, then the first time the process encounters a timeout, it will receive a SIGTERM.
+**How to enable** To enable this behavior you can set `term_on_timeout: 1` to an integer value. If you set it to one, then the first time the process encounters a timeout, it will receive a SIGTERM.
 
 To enable on Heroku run:
 

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -53,8 +53,6 @@ module Rack
       when nil   ; read_timeout_property default, default
       when false ; false
       when 0     ; false
-      when String
-        read_timeout_property value.to_i, default
       else
         value.is_a?(Numeric) && value > 0 or raise ArgumentError, "value #{value.inspect} should be false, zero, or a positive number."
         value
@@ -69,7 +67,7 @@ module Rack
       :term_on_timeout
 
     def initialize(app, service_timeout:nil, wait_timeout:nil, wait_overtime:nil, service_past_wait:"not_specified", term_on_timeout: nil)
-      @term_on_timeout   = read_timeout_property term_on_timeout, ENV.fetch("RACK_TIMEOUT_TERM_ON_TIMEOUT", false)
+      @term_on_timeout   = read_timeout_property term_on_timeout, ENV.fetch("RACK_TIMEOUT_TERM_ON_TIMEOUT", 0).to_i
       @service_timeout   = read_timeout_property service_timeout, ENV.fetch("RACK_TIMEOUT_SERVICE_TIMEOUT", 15).to_i
       @wait_timeout      = read_timeout_property wait_timeout,    ENV.fetch("RACK_TIMEOUT_WAIT_TIMEOUT", 30).to_i
       @wait_overtime     = read_timeout_property wait_overtime,   ENV.fetch("RACK_TIMEOUT_WAIT_OVERTIME", 60).to_i
@@ -77,7 +75,6 @@ module Rack
 
       Thread.main['RACK_TIMEOUT_COUNT'] ||= 0
       if @term_on_timeout
-        raise "term_on_timeout must be an integer but is #{@term_on_timeout.class}: #{@term_on_timeout}" unless @term_on_timeout.is_a?(Numeric)
         raise "Current Runtime does not support processes" unless ::Process.respond_to?(:fork)
       end
       @app = app


### PR DESCRIPTION
The standard convention is that `0` is false in the Rack Timeout config. We don't need to special case this false value. Reverting to prior logic and updating documentation.