### PR TITLE
Be able to configure Rack::Timeout with strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ## 0.6.0
 
 - Allow sending SIGTERM to workers on timeout (https://github.com/sharpstone/rack-timeout/pull/157)
+- Add support to configure `Rack::Timeout` using strings ([#157], [#165])
+
+[#157]: https://github.com/sharpstone/rack-timeout/pull/157
+[#165]: https://github.com/sharpstone/rack-timeout/pull/165
 
 0.5.2
 =====

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -53,6 +53,8 @@ module Rack
       when nil   ; read_timeout_property default, default
       when false ; false
       when 0     ; false
+      when String
+        read_timeout_property value.to_i, default
       else
         value.is_a?(Numeric) && value > 0 or raise ArgumentError, "value #{value.inspect} should be false, zero, or a positive number."
         value

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -7,6 +7,12 @@ class BasicTest < RackTimeoutTest
     assert last_response.ok?
   end
 
+  def test_settings_with_strings
+    self.settings = { service_timeout: "1" }
+    get "/"
+    assert last_response.ok?
+  end
+
   def test_timeout
     self.settings = { service_timeout: 1 }
     assert_raises(Rack::Timeout::RequestTimeoutError) do


### PR DESCRIPTION
This was originally added as part of #157, and released in 0.6.0.

Then it was reverted in #161, but I think it should be kept in, as
removing it is a breaking change. (Yeah, I know this gem is not 1.0 yet,
but will it ever be? :-) It has soon existed for 10 years.)

It is useful, as it allows you to use Rack::Timeout like this:

    use Rack::Timeout, service_timeout: ENV.fetch("RACK_TIMEOUT_SERVICE_TIMEOUT")