### PR TITLE
CI: Keep only in-support Ruby versions in matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 rvm:
-  - 2.5.1
-  - 2.4.4
-  - 2.3.7
-  - 2.2.10
+  - 2.7
+  - 2.6
+  - 2.5
 branches:
   only:
     - master


### PR DESCRIPTION
This removes all of the EOL'd versions. Source for version EOLs: https://www.ruby-lang.org/en/downloads/branches/